### PR TITLE
feat(NTC-5045): add MH_CLEAN_ON_START cleanup mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,13 @@ func main() {
 
 	configure()
 
+	if conf.CleanOnStart {
+		if err := runCleanOnStart(conf); err != nil {
+			log.Fatalf("cleanup failed: %s", err)
+		}
+		os.Exit(0)
+	}
+
 	if conf.AuthFile != "" {
 		web.AuthFile(conf.AuthFile)
 	}
@@ -65,4 +72,16 @@ func main() {
 
 	<-exitCh
 	log.Printf("Received exit signal")
+}
+
+// runCleanOnStart deletes all messages from the configured storage backend.
+// Used to run MailHog as a one-shot cleanup job (e.g. from a cronjob) instead
+// of starting the SMTP/HTTP listeners.
+func runCleanOnStart(conf *config.Config) error {
+	log.Info("MH_CLEAN_ON_START set: deleting all messages and exiting")
+	if err := conf.Storage.DeleteAll(); err != nil {
+		return err
+	}
+	log.Info("cleanup complete")
+	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/doctolib/MailHog/pkg/config"
+	"github.com/doctolib/MailHog/pkg/data"
+	"github.com/doctolib/MailHog/pkg/storage"
+)
+
+// failingStorage wraps a real Storage and forces DeleteAll to fail, to
+// exercise the error path of runCleanOnStart without a real backend.
+type failingStorage struct {
+	storage.Storage
+}
+
+func (f *failingStorage) DeleteAll() error {
+	return errors.New("boom")
+}
+
+func TestRunCleanOnStart(t *testing.T) {
+	Convey("runCleanOnStart", t, func() {
+		Convey("deletes all messages and returns nil on success", func() {
+			s := storage.CreateInMemory()
+			_, err := s.Store(&data.Message{
+				ID: data.MessageID("test-message"),
+				Content: &data.Content{
+					Body: "test",
+				},
+			})
+			So(err, ShouldBeNil)
+			So(s.Count(), ShouldEqual, 1)
+
+			conf := &config.Config{Storage: s}
+			err = runCleanOnStart(conf)
+
+			So(err, ShouldBeNil)
+			So(s.Count(), ShouldEqual, 0)
+		})
+
+		Convey("returns the storage error on failure", func() {
+			conf := &config.Config{Storage: &failingStorage{}}
+
+			err := runCleanOnStart(conf)
+
+			So(err, ShouldNotBeNil)
+		})
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ func DefaultConfig() *Config {
 // Config is the config, kind of
 type Config struct {
 	Verbose            bool
+	CleanOnStart       bool
 	SMTPBindAddr       string
 	HTTPBindAddr       string
 	Hostname           string
@@ -150,6 +151,7 @@ func Configure() *Config {
 // RegisterFlags registers flags
 func RegisterFlags() {
 	flag.BoolVar(&cfg.Verbose, "verbose", envconf.FromEnvP("MH_VERBOSE", false).(bool), "Be verbose (TRACE log level)")
+	flag.BoolVar(&cfg.CleanOnStart, "clean-on-start", envconf.FromEnvP("MH_CLEAN_ON_START", false).(bool), "Delete all messages from storage and exit immediately, without starting the SMTP/HTTP listeners")
 	flag.StringVar(&cfg.SMTPBindAddr, "smtp-bind-addr", envconf.FromEnvP("MH_SMTP_BIND_ADDR", "0.0.0.0:1025").(string), "SMTP bind interface and port, e.g. 0.0.0.0:1025 or just :1025")
 	flag.StringVar(&cfg.HTTPBindAddr, "api-bind-addr", envconf.FromEnvP("MH_API_BIND_ADDR", "0.0.0.0:8025").(string), "HTTP bind interface and port for API, e.g. 0.0.0.0:8025 or just :8025")
 	flag.StringVar(&cfg.Hostname, "hostname", envconf.FromEnvP("MH_HOSTNAME", "mailhog.example").(string), "Hostname for EHLO/HELO response, e.g. mailhog.example")


### PR DESCRIPTION
[NTC-5045](https://doctolib.atlassian.net/browse/NTC-5045)

Adds a one-shot cleanup mode to the MailHog binary, gated by the `MH_CLEAN_ON_START`
env var (default `false`). When set, the binary deletes all messages from the
configured storage backend via `Storage.DeleteAll()` (same call the
`DELETE /api/v1/messages` API handler uses) and exits, instead of starting the
SMTP/HTTP listeners.

## Why an env var instead of a command

This replaces the old curl-based `DELETE` loop cronjob
(`models/mailhog/01-mailhog.rb`'s `MailhogCleanerCronJob` in `kube`). That
approach doesn't translate to the new deployment-descriptor system: the
descriptor CRD has no `command`/`args` field for cronjob runtimes (K8s prunes
the field before the controller sees it, and the repo's schema-validation hook
rejects it outright). The only way to parameterize a descriptor runtime is via
`environment:` (a plain env var map), so the "command" has to be fixed at
image-build time and switched by env var instead of overridden per-deployment.

## How this env var gets used to actually run the delete job

The env var doesn't do anything by itself — it's inert until the `kube` side
(follow-up PR, not in this one) wires it up. Once it does:

- A new `mailhog-cleaner` **cronjob runtime** gets added to the `mailhog`
  deployment descriptor, pointing at the **exact same image/digest** as the
  `mailhog` server runtime (no new image, no new rollout).
- Its `environment:` block sets `MH_CLEAN_ON_START: "true"` (plus
  `MH_STORAGE: postgres`, so the binary actually connects to the real Postgres
  storage rather than defaulting to in-memory).
- Kubernetes' CronJob controller creates a fresh Pod from that image on the
  configured schedule (`0 0 * * *`, matching the old `@midnight`). Each run is
  a brand-new container start — there's no long-lived process to "trigger" the
  cleanup in; the env var is simply present from the moment the container
  starts.
- Because `MH_CLEAN_ON_START=true` is set, `main()` takes the new branch added
  in this PR right after `configure()`, calls `runCleanOnStart`, and exits
  before ever reaching `web.Listen`/`smtp.Listen` — so the Pod never opens the
  SMTP/HTTP ports, does the deletion, and terminates. K8s sees the container
  exit 0 (success) or non-zero (failure, surfaced as a failed Job) and reports
  cronjob health accordingly, the same way it would for any other batch Job.
- The regular `mailhog` server deployment never sets this env var, so it always
  takes the normal path and behaves exactly as it does today — this PR is a
  no-op for the running server.

In short: same image, same binary, two entrypoints reachable only via which env
vars a given descriptor runtime sets — the "deployment" runtime always serves
traffic, the "cronjob" runtime always cleans up and exits.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [ ] Verify in staging once the `kube`/`docker-images` follow-ups land: the
      `mailhog-cleaner` Job runs to completion, deletes messages, exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NTC-5045]: https://doctolib.atlassian.net/browse/NTC-5045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ