### PR TITLE
fix(NTC-5045): decouple make build from golangci-lint/gox install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,18 +25,18 @@ test: deps assets
 
 .PHONY: release
 release: deps assets test lint
+	go install github.com/mitchellh/gox@v${GOX_VERSION}
 	gox -ldflags "-X main.version=${VERSION}" -output="build/{{.Dir}}_{{.OS}}_{{.Arch}}" .
 
 .PHONY: lint
 lint: deps
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_VERSION}
 	golangci-lint run
 
 .PHONY: deps
 deps:
 	go mod download
 	go install github.com/go-bindata/go-bindata/go-bindata@v${GOBINDATA_VERSION}
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_VERSION}
-	go install github.com/mitchellh/gox@v${GOX_VERSION}
 
 .PHONY: assets
 assets: deps


### PR DESCRIPTION
## Why

[NTC-5045](https://doctolib.atlassian.net/browse/NTC-5045)

`Makefile`'s `build` target depends on `deps`, which unconditionally installs `golangci-lint@v2.12.2`. That version requires Go ≥ 1.25.0, but `non_static/mailhog/Dockerfile` in `doctolib/docker-images` builds this image with `golang:1.24.3-bullseye`, so `make build` fails there with `make: *** [Makefile:38: deps] Error 1` before it ever compiles the binary — even though building has nothing to do with linting.

This regression was introduced in fb0c6b2 ("ci: add CI workflow, upgrade golangci-lint to v2.12.2 (#24)") but only surfaced now because doctolib/docker-images PR [#23015](https://github.com/doctolib/docker-images/pull/23015) re-pins `MAILHOG_VERSION` to a commit built on top of it. It only reproduces with a Go toolchain older than 1.25 (e.g. the `golang:1.24.3-bullseye` builder image) — `make build` on `master` already succeeds with a newer local Go toolchain, since golangci-lint's version constraint isn't hit.

This is unrelated to the actual NTC-5045 cleanup-cronjob feature — it's an unblocking fix surfaced by that re-pin.

## How

Split `deps` so it only installs what `build`/`assets`/`queries`/`test` actually need (`go mod download` + `go-bindata`). Moved the `golangci-lint` install into `lint` and the `gox` install into `release`, right before they're used.

## Changes

- Removed `golangci-lint` and `gox` installs from `deps`
- Added the `golangci-lint` install to `lint`
- Added the `gox` install to `release`

## Evidence of Testing

Verified locally (Go 1.26.5, so `deps` on `master` doesn't hit the Go-version failure here — this confirms the split doesn't break anything, not that it reproduces the original bug):
- `go build ./...` — succeeds
- `make build` — succeeds, and no longer touches golangci-lint/gox at all
- `make lint` — succeeds (still installs and runs golangci-lint, just later)
- `make test` — succeeds
- `go vet ./...` — succeeds

Not reproduced/re-tested against `golang:1.24.3-bullseye` directly; the fix removes the golangci-lint install from `build`'s dependency chain entirely, so the Go-version constraint can no longer block it regardless of toolchain.

## Review Focus

Correctness of the Makefile target dependency split — confirming `build`/`test`/`assets`/`queries`/`all` behavior is unchanged.

## Documentation

N/A

---
_This pull request was created with AI assistance._

[NTC-5045]: https://doctolib.atlassian.net/browse/NTC-5045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ