### PR TITLE
fix(NTC-5045): set REPLICA IDENTITY FULL on messages table

### DIFF
--- a/queries/postgresql-schema.sql
+++ b/queries/postgresql-schema.sql
@@ -12,6 +12,12 @@ CREATE TABLE IF NOT EXISTS messages (
     message jsonb
 );
 
+-- messages has no primary key, so the default replica identity (which requires
+-- one) can't cover DELETEs. Namespaces with a FOR ALL TABLES CDC publication
+-- enabled (a platform-wide Terraform default) reject DELETE FROM messages
+-- without this, regardless of this app's own cdc.enabled setting.
+ALTER TABLE messages REPLICA IDENTITY FULL;
+
 CREATE INDEX IF NOT EXISTS messages_expr_idx ON messages USING btree (((message -> 'Created'::text)));
 CREATE INDEX IF NOT EXISTS messages_expr_idx2 ON messages USING btree (((message ->> 'ID'::text)));
 


### PR DESCRIPTION
[NTC-5045](https://doctolib.atlassian.net/browse/NTC-5045)

## Problem

Testing the new `mailhog-cleaner` cronjob (built on `MH_CLEAN_ON_START`, #38)
against the dedicated deployment-descriptor `mailhog` namespace's Aurora
database, the cleanup job failed on startup:

> can't `DELETE FROM messages` because that table has no replica identity,
> while its dedicated Aurora database has a `FOR ALL TABLES` CDC publication
> (`enable_publication=true` in `mailhog.autogenerated.tf`) that requires one
> for deletes

That CDC publication is a platform-wide Terraform default, unrelated to this
app's own `cdc.enabled: false` descriptor setting — so it isn't something we
can turn off from here. The `messages` table itself has no primary key, so
Postgres' default replica identity (which requires one) can't cover it either.
The fix is DB-side: give the table an explicit replica identity that doesn't
need a primary key.

(The older `models/mailhog/01-mailhog.rb` deployment, in the shared
`staging-aws-fr-par-1` namespace, never hit this — different DB path, and its
cleaner never triggers a delete configuration where this matters.)

## Fix

Add to `queries/postgresql-schema.sql`:
```sql
ALTER TABLE messages REPLICA IDENTITY FULL;
```

This file already runs on **every** connection (`createPostgreSQL()` in
`pkg/storage/postgresql.go` executes it right after connecting, same as the
table/index `CREATE ... IF NOT EXISTS` statements), so this self-heals on
every deploy/restart with no separate migration step — consistent with how
the rest of the schema file is already idempotent.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [x] Verified locally against real Postgres: `SELECT relreplident FROM
      pg_class WHERE relname = 'messages'` was empty on a fresh DB, ran the
      binary once, confirmed it flipped to `f` (FULL)
- [ ] Verify in staging once `docker-images`/`kube` are re-pinned: the
      `mailhog-cleaner` Job runs to completion without the replica-identity
      error

## Rollout note

`docker-images` was already re-pinned once (to `master`'s tip at the time,
`dfc87a4` — includes #38 but not this fix) specifically to build the image
used to test the `mailhog-cleaner` cronjob — that test is what surfaced this
bug. This PR isn't in that image yet. Once this PR merges, `docker-images`
needs a **second** re-pin (to the new `master` tip, now including both #38 and
this fix) before the `kube` descriptor's `version:` gets bumped and the
cronjob is retested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NTC-5045]: https://doctolib.atlassian.net/browse/NTC-5045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ