### PR TITLE
fix(NTC-5128): batch DeleteAll to avoid timeout and read-only transaction errors

### DIFF
--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -237,6 +237,7 @@ func (pg *PostgreSQL) DeleteAll() error {
 			return err
 		}
 		if err := tx.Commit(context.TODO()); err != nil {
+			tx.Rollback(context.TODO())
 			conn.Release()
 			return err
 		}

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -211,17 +211,39 @@ func (pg *PostgreSQL) DeleteOne(id string) error {
 	return nil
 }
 
-// DeleteAll deletes all messages stored in PostgreSQL
+// deleteAllBatchSize is the number of rows removed per iteration in DeleteAll.
+// Declared as a var so tests can override it to exercise multi-batch behaviour
+// without storing thousands of messages.
+var deleteAllBatchSize = 1000
+
+// DeleteAll deletes all messages stored in PostgreSQL in batches to avoid statement timeouts.
 func (pg *PostgreSQL) DeleteAll() error {
 	log.Debugf("Deleting all messages")
-	conn, err := pg.Pool.Acquire(context.TODO())
-	if err != nil {
-		return err
-	}
-	defer conn.Release()
-	if _, err := conn.Exec(context.TODO(), "DELETE FROM messages"); err != nil {
-		log.Errorf("Delete error %v", err)
-		return err
+	for {
+		conn, err := pg.Pool.Acquire(context.TODO())
+		if err != nil {
+			return err
+		}
+		tx, err := conn.BeginTx(context.TODO(), pgx.TxOptions{AccessMode: pgx.ReadWrite})
+		if err != nil {
+			conn.Release()
+			return err
+		}
+		tag, err := tx.Exec(context.TODO(), "DELETE FROM messages WHERE ctid IN (SELECT ctid FROM messages LIMIT $1)", deleteAllBatchSize)
+		if err != nil {
+			tx.Rollback(context.TODO())
+			conn.Release()
+			log.Errorf("Delete error %v", err)
+			return err
+		}
+		if err := tx.Commit(context.TODO()); err != nil {
+			conn.Release()
+			return err
+		}
+		conn.Release()
+		if tag.RowsAffected() == 0 {
+			break
+		}
 	}
 	return nil
 }

--- a/pkg/storage/postgresql_test.go
+++ b/pkg/storage/postgresql_test.go
@@ -38,6 +38,20 @@ func TestPostgreSQLDeleteAll(t *testing.T) {
 	})
 }
 
+func TestPostgreSQLDeleteAllBatched(t *testing.T) {
+	Convey("test postgresql message delete-all with multiple batches", t, func() {
+		s := createTestPostgreSQLstorage(t)
+		So(s, ShouldNotBeNil)
+		defer cleanupPostgreSQL(s)
+
+		original := deleteAllBatchSize
+		deleteAllBatchSize = 2
+		defer func() { deleteAllBatchSize = original }()
+
+		testDeleteAllBatched(s)
+	})
+}
+
 func TestPostgreSQLList(t *testing.T) {
 	Convey("test mongodb message list", t, func() {
 		s := createTestPostgreSQLstorage(t)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -130,6 +130,35 @@ func testDeleteAll(s Storage) {
 	})
 }
 
+// testDeleteAllBatched verifies that DeleteAll removes every message even when
+// the total exceeds the batch size, i.e. that the loop runs multiple iterations.
+// Call this after setting deleteAllBatchSize to a value smaller than the number
+// of messages you store so that at least two batches are required.
+func testDeleteAllBatched(s Storage) {
+	Convey("test message delete-all with multiple batches", func() {
+		messages := []*data.Message{
+			newSimpleMessage("a@mailient.test", "b@mailient.test", "msg 1", "body 1"),
+			newSimpleMessage("a@mailient.test", "b@mailient.test", "msg 2", "body 2"),
+			newSimpleMessage("a@mailient.test", "b@mailient.test", "msg 3", "body 3"),
+			newSimpleMessage("a@mailient.test", "b@mailient.test", "msg 4", "body 4"),
+			newSimpleMessage("a@mailient.test", "b@mailient.test", "msg 5", "body 5"),
+		}
+
+		So(s.Count(), ShouldEqual, 0)
+
+		for _, message := range messages {
+			_, err := s.Store(cloneMessage(message))
+			So(err, ShouldBeNil)
+		}
+
+		So(s.Count(), ShouldEqual, len(messages))
+
+		err := s.DeleteAll()
+		So(err, ShouldBeNil)
+		So(s.Count(), ShouldEqual, 0)
+	})
+}
+
 // testList tests s.Count, s.Store, and s.List
 func testList(s Storage) {
 	message := newSimpleMessage(


### PR DESCRIPTION
[NTC-5128](https://doctolib.atlassian.net/browse/NTC-5128)

## Problem

The `mailhog-cleaner` CronJob (added in #38) opens its own PostgreSQL connection and calls `DeleteAll()` directly. Two errors were observed in production:

```
level=error msg="Delete error ERROR: canceling statement due to statement timeout (SQLSTATE 57014)"
level=error msg="Delete error ERROR: cannot execute DELETE in a read-only transaction (SQLSTATE 25006)"
```

**Statement timeout**: `DeleteAll()` ran `DELETE FROM messages` — a single unbounded statement over the full table. On a large table this hits the server's `statement_timeout`.

**Read-only transaction**: `DeleteAll()` ran the DELETE in implicit autocommit mode. If the PostgreSQL session has `default_transaction_read_only = on` set at the role or session level, implicit transactions inherit that setting and reject write statements. The previous curl-based cronjob never hit this because it called the running server's HTTP API, reusing the server's already-established connection.

## Fix

`DeleteAll()` in `pkg/storage/postgresql.go` now:

1. **Batches deletions** — removes 1000 rows at a time via `DELETE FROM messages WHERE ctid IN (SELECT ctid FROM messages LIMIT $1)`, looping until the table is empty. Each batch is a short, bounded operation that stays within any statement timeout.
2. **Explicitly opens a read-write transaction** per batch via `conn.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadWrite})`, which overrides any session-level `default_transaction_read_only` setting.
3. **Releases connections between batches** — at most one pool connection held at a time across the loop.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] Added `TestPostgreSQLDeleteAllBatched`: overrides batch size to 2, stores 5 messages, asserts all are deleted — confirms the loop runs multiple iterations correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NTC-5128]: https://doctolib.atlassian.net/browse/NTC-5128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ