### PR TITLE
fix(NTC-5128): set statement_timeout = 0 per batch transaction in DeleteAll

### DIFF
--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -237,6 +237,7 @@ func (pg *PostgreSQL) DeleteAll() error {
 			return err
 		}
 		if err := tx.Commit(context.TODO()); err != nil {
+			tx.Rollback(context.TODO())
 			conn.Release()
 			return err
 		}

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -229,6 +229,13 @@ func (pg *PostgreSQL) DeleteAll() error {
 			conn.Release()
 			return err
 		}
+		// Disable statement timeout for this transaction only: each batch may be
+		// slow due to WAL writes (REPLICA IDENTITY FULL + CDC publication).
+		if _, err := tx.Exec(context.TODO(), "SET LOCAL statement_timeout = 0"); err != nil {
+			tx.Rollback(context.TODO())
+			conn.Release()
+			return err
+		}
 		tag, err := tx.Exec(context.TODO(), "DELETE FROM messages WHERE ctid IN (SELECT ctid FROM messages LIMIT $1)", deleteAllBatchSize)
 		if err != nil {
 			tx.Rollback(context.TODO())

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -211,17 +211,39 @@ func (pg *PostgreSQL) DeleteOne(id string) error {
 	return nil
 }
 
-// DeleteAll deletes all messages stored in PostgreSQL
+// deleteAllBatchSize is the number of rows removed per iteration in DeleteAll.
+// Declared as a var so tests can override it to exercise multi-batch behaviour
+// without storing thousands of messages.
+var deleteAllBatchSize = 1000
+
+// DeleteAll deletes all messages stored in PostgreSQL in batches to avoid statement timeouts.
 func (pg *PostgreSQL) DeleteAll() error {
 	log.Debugf("Deleting all messages")
-	conn, err := pg.Pool.Acquire(context.TODO())
-	if err != nil {
-		return err
-	}
-	defer conn.Release()
-	if _, err := conn.Exec(context.TODO(), "DELETE FROM messages"); err != nil {
-		log.Errorf("Delete error %v", err)
-		return err
+	for {
+		conn, err := pg.Pool.Acquire(context.TODO())
+		if err != nil {
+			return err
+		}
+		tx, err := conn.BeginTx(context.TODO(), pgx.TxOptions{AccessMode: pgx.ReadWrite})
+		if err != nil {
+			conn.Release()
+			return err
+		}
+		tag, err := tx.Exec(context.TODO(), "DELETE FROM messages WHERE ctid IN (SELECT ctid FROM messages LIMIT $1)", deleteAllBatchSize)
+		if err != nil {
+			tx.Rollback(context.TODO())
+			conn.Release()
+			log.Errorf("Delete error %v", err)
+			return err
+		}
+		if err := tx.Commit(context.TODO()); err != nil {
+			conn.Release()
+			return err
+		}
+		conn.Release()
+		if tag.RowsAffected() == 0 {
+			break
+		}
 	}
 	return nil
 }

--- a/pkg/storage/postgresql_test.go
+++ b/pkg/storage/postgresql_test.go
@@ -38,6 +38,20 @@ func TestPostgreSQLDeleteAll(t *testing.T) {
 	})
 }
 
+func TestPostgreSQLDeleteAllBatched(t *testing.T) {
+	Convey("test postgresql message delete-all with multiple batches", t, func() {
+		s := createTestPostgreSQLstorage(t)
+		So(s, ShouldNotBeNil)
+		defer cleanupPostgreSQL(s)
+
+		original := deleteAllBatchSize
+		deleteAllBatchSize = 2
+		defer func() { deleteAllBatchSize = original }()
+
+		testDeleteAllBatched(s)
+	})
+}
+
 func TestPostgreSQLList(t *testing.T) {
 	Convey("test mongodb message list", t, func() {
 		s := createTestPostgreSQLstorage(t)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -130,6 +130,35 @@ func testDeleteAll(s Storage) {
 	})
 }
 
+// testDeleteAllBatched verifies that DeleteAll removes every message even when
+// the total exceeds the batch size, i.e. that the loop runs multiple iterations.
+// Call this after setting deleteAllBatchSize to a value smaller than the number
+// of messages you store so that at least two batches are required.
+func testDeleteAllBatched(s Storage) {
+	Convey("test message delete-all with multiple batches", func() {
+		messages := []*data.Message{
+			newSimpleMessage("a@mailient.test", "b@mailient.test", "msg 1", "body 1"),
+			newSimpleMessage("a@mailient.test", "b@mailient.test", "msg 2", "body 2"),
+			newSimpleMessage("a@mailient.test", "b@mailient.test", "msg 3", "body 3"),
+			newSimpleMessage("a@mailient.test", "b@mailient.test", "msg 4", "body 4"),
+			newSimpleMessage("a@mailient.test", "b@mailient.test", "msg 5", "body 5"),
+		}
+
+		So(s.Count(), ShouldEqual, 0)
+
+		for _, message := range messages {
+			_, err := s.Store(cloneMessage(message))
+			So(err, ShouldBeNil)
+		}
+
+		So(s.Count(), ShouldEqual, len(messages))
+
+		err := s.DeleteAll()
+		So(err, ShouldBeNil)
+		So(s.Count(), ShouldEqual, 0)
+	})
+}
+
 // testList tests s.Count, s.Store, and s.List
 func testList(s Storage) {
 	message := newSimpleMessage(


### PR DESCRIPTION
[NTC-5128](https://doctolib.atlassian.net/browse/NTC-5128)

Follow-up to #44, which was tested on staging and still hit the statement timeout.

## Problem

Even with 1000-row batches, the `DELETE FROM messages WHERE ctid IN (...)` was still cancelling with `SQLSTATE 57014`. The reason: each deleted row triggers WAL writes containing its full JSON body (`REPLICA IDENTITY FULL` + active CDC publication), so the I/O cost per batch is driven by total message size, not just row count.

The connection acquired by `DeleteAll()` comes fresh from the pool — it does **not** inherit the `SET statement_timeout = 0` that the schema migration sets on its own connection, so the server's default timeout applies.

## Fix

Add `SET LOCAL statement_timeout = 0` as the first statement inside each batch transaction. `SET LOCAL` is scoped to the current transaction and resets automatically on commit or rollback, so it does not bleed into other pool connections.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [ ] Verify on staging: cleaner job runs to completion without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NTC-5128]: https://doctolib.atlassian.net/browse/NTC-5128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ